### PR TITLE
Added Dockerfile and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # spring-authorization-server
 spring-authorization-server demo
+
+ - [UAA Server Documentation](uaa-server%2FREADME.md)
+ - [API Key Auth Provider Documentation](apikey-auth-provider%2FREADME.md)
+ - [Resource Server Documentation](resource-server%2FREADME.md)

--- a/apikey-auth-provider/Dockerfile
+++ b/apikey-auth-provider/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official OpenJDK runtime as a parent image
+FROM openjdk:17-jre-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the application's JAR file into the container
+COPY build/libs/apikey-auth-provider-1.0.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 9090
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apikey-auth-provider/README.md
+++ b/apikey-auth-provider/README.md
@@ -1,0 +1,51 @@
+# API Key Auth Provider
+
+## Overview
+
+The API Key Auth Provider is a microservice that handles API key authentication. It uses Spring Boot, Spring Security, and OAuth2 for managing secure client authentication and API key retrieval.
+
+## Prerequisites
+
+- Java 17
+- Gradle
+- Docker (for containerization)
+
+
+## Configuration
+
+The `application.yml` file contains the necessary configuration for the API Key Auth Provider, including client registration details, security settings, and the API endpoint for retrieving API keys.
+
+## Build with Gradle
+
+To build the project, run:
+
+```bash
+./gradlew clean build
+```
+
+## Run Locally
+To run the application locally, use:
+
+```bash
+./gradlew bootRun
+```
+
+## Build Docker Image
+To build the Docker image, execute:
+
+```bash
+docker build -t apikey-auth-provider .
+```
+
+Run Docker Container
+To run the Docker container, use:
+
+```bash
+docker run -p 9090:9090 apikey-auth-provider
+```
+
+## Contributions
+Pleas feel free to fork this repository and contribute by submitting a pull request. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+This project is licensed under the MIT License.

--- a/uaa-server/Dockerfile
+++ b/uaa-server/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official OpenJDK runtime as a parent image
+FROM openjdk:17-jre-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the application's JAR file into the container
+COPY build/libs/uaa-server-1.0.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 9000
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/uaa-server/README.md
+++ b/uaa-server/README.md
@@ -1,0 +1,61 @@
+# UAA Server
+
+## Overview
+
+The UAA (User Account and Authentication) Server is a microservice that acts as an authorization server, handling authentication and issuing tokens. It uses Spring Boot, Spring Security, and OAuth2 for managing secure user authentication and authorization.
+
+## Prerequisites
+
+- Java 17
+- Gradle 8.5+
+- Docker (for containerization)
+
+
+## Configuration
+
+The `application.yml` file contains the necessary configuration for the UAA server, including client registration details and security settings.
+
+## Build with Gradle
+
+To build the project, run:
+
+```bash
+./gradlew clean build
+```
+
+## Run Locally
+To run the application locally, use:
+
+```bash
+./gradlew bootRun
+```
+
+## Build Docker Image
+To build the Docker image, execute:
+
+```bash
+docker build -t uaa-server .
+```
+
+## Run Docker Container
+To run the Docker container, use:
+
+```bash
+docker run -p 9000:9000 uaa-server
+```
+
+## Hosts Configuration
+For proper communication between the microservices, ensure you add the following entry in the /etc/hosts file:
+
+```bash
+127.0.0.1 uaa-server
+```
+
+This will allow other microservices to communicate with the UAA server using the hostname `uaa-server`.
+
+
+## Contributions
+Pleas feel free to fork this repository and contribute by submitting a pull request. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+This project is licensed under the MIT License.


### PR DESCRIPTION
- Added Dockerfile for apikey-auth-provider microservice to enable containerization using OpenJDK 17.
- Updated README.md with instructions on how to build and run the Docker container for the apikey-auth-provider microservice.
- Detailed steps included for Docker image build and container run commands.